### PR TITLE
fix: use root .gitignore instead of info/exclude for workspace cleanliness

### DIFF
--- a/template/AGENTS.md
+++ b/template/AGENTS.md
@@ -79,5 +79,6 @@ mise run remote-add owner/repo
 
 ## Local excludes
 
-Project-root files are excluded via `.bare/info/exclude`, not `.gitignore`. If you add new
-untracked files at the root, add their patterns there.
+The project root has a `.gitignore` containing `*` so all root-level files stay untracked.
+This only affects the `_workspace` checkout; linked worktrees have their own `.gitignore`.
+Use `.bare/info/exclude` only for patterns that should apply across all worktrees.

--- a/template/setup.sh.jinja
+++ b/template/setup.sh.jinja
@@ -28,30 +28,17 @@ fi
 
 # Make git status work at the project root so shell prompts (starship, etc.)
 # don't show spurious indicators. An empty orphan branch means "nothing tracked
-# here" and .bare/info/exclude hides all the untracked project-root files.
+# here" and a wildcard .gitignore hides all untracked project-root files.
 git config core.bare false
 EMPTY_TREE=$(git hash-object -t tree /dev/null)
 EMPTY_COMMIT=$(echo "workspace root" | git commit-tree "$EMPTY_TREE")
 git update-ref refs/heads/_workspace "$EMPTY_COMMIT"
 git symbolic-ref HEAD refs/heads/_workspace
 
-# Set up local excludes (these stay outside version control)
-cat >> .bare/info/exclude << 'EXCLUDE'
-
-# Project-level files (outside version control)
-.mise/
-.mise.toml
-_/
-.claude/
-.cursor/
-AGENTS.md
-CLAUDE.md
-*.env
-.env.*
-flake.nix
-flake.lock
-.copier-answers.yml
-EXCLUDE
+# The project root is on the _workspace branch (empty tree). A wildcard .gitignore
+# here keeps git status clean without polluting .bare/info/exclude, which is
+# shared across all linked worktrees.
+echo "*" > .gitignore
 
 # Create directories for scratchpad and agent config
 mkdir -p _ .claude


### PR DESCRIPTION
## Summary
- `.bare/info/exclude` is shared across all linked worktrees, so patterns meant for the project root (`.mise/`, `AGENTS.md`, etc.) were also hiding those names inside worktrees
- Replaces the `info/exclude` approach with a wildcard `.gitignore` at the project root, which only affects the `_workspace` checkout
- Fixes `.bare/` and `main/` (and any dynamically-created worktree dirs) showing as untracked in `git status` at the project root

## Test plan
- [x] Scaffold fresh project (no remote): `git status` returns clean
- [x] Scaffold with remote URL: `git status` returns clean
- [x] Files inside linked worktrees are visible (not hidden by shared excludes)
- [x] Dynamically-added worktrees don't appear as untracked at root

🤖 Generated with [Claude Code](https://claude.com/claude-code)