### PR TITLE
feat: add wt-update, wt-destroy tasks and fetch-before-add

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,8 @@
 
 A [copier](https://copier.readthedocs.io/) template that scaffolds git projects using the
 **bare repo + worktree** pattern described in
-[Git Worktrees Done Right](https://gabri.me/blog/git-worktrees-done-right).
+[Git Worktrees Done Right](https://gabri.me/blog/git-worktrees-done-right) and its followup
+[git-wt: Worktrees Simplified](https://gabri.me/blog/git-wt) by Ahmed el Gabri.
 
 Instead of switching branches with `git checkout`, you keep multiple branches checked out
 simultaneously as separate directories (worktrees). A bare clone holds all git data, and
@@ -44,7 +45,9 @@ my-project/
 │   └── tasks/       # Project tasks
 │       ├── wt-add       # Create a new worktree
 │       ├── wt-rm        # Remove a worktree
+│       ├── wt-destroy   # Remove worktree + local + remote branch
 │       ├── wt-ls        # List all worktrees
+│       ├── wt-update    # Fetch remotes and fast-forward main
 │       ├── repo-public  # Create a public GitHub repo
 │       ├── repo-private # Create a private GitHub repo
 │       └── remote-add   # Add a remote to an existing repo
@@ -70,8 +73,14 @@ cd my-feature/
 # List all worktrees
 mise run wt-ls
 
-# Clean up when done
+# Fetch latest and fast-forward main
+mise run wt-update
+
+# Clean up when done (keeps remote branch)
 mise run wt-rm my-feature
+
+# Or nuke everything: worktree + local + remote branch
+mise run wt-destroy my-feature
 ```
 
 The `main/` worktree stays pristine as a clean reference for diffing. Never edit files in it
@@ -164,9 +173,11 @@ outside version control.
 
 | Task | Usage | Description |
 |------|-------|-------------|
-| `wt-add` | `mise run wt-add <branch> [base]` | Create a new worktree. Defaults to branching from `main`. |
-| `wt-rm` | `mise run wt-rm <branch>` | Remove a worktree and its directory. |
+| `wt-add` | `mise run wt-add <branch> [base]` | Create a new worktree. Fetches remotes first, defaults to branching from `main`. |
+| `wt-rm` | `mise run wt-rm <branch>` | Remove a worktree and its local branch. |
+| `wt-destroy` | `mise run wt-destroy <branch>` | Remove a worktree and delete both local and remote branches. |
 | `wt-ls` | `mise run wt-ls` | List all active worktrees. |
+| `wt-update` | `mise run wt-update` | Fetch all remotes and fast-forward `main`. |
 | `repo-public` | `mise run repo-public <owner/repo>` | Create a public GitHub repo, set up remote, and push `main`. |
 | `repo-private` | `mise run repo-private <owner/repo>` | Create a private GitHub repo, set up remote, and push `main`. |
 | `remote-add` | `mise run remote-add <owner/repo> [name]` | Add an existing GitHub repo as remote and push `main`. Defaults remote name to `origin`. |
@@ -179,5 +190,11 @@ To add your own, edit `.bare/info/exclude` directly.
 
 ## Credit
 
-Based on the workflow from [Git Worktrees Done Right](https://gabri.me/blog/git-worktrees-done-right)
-by Ahmed el Gabri.
+Based on the workflow from Ahmed el Gabri:
+
+- [Git Worktrees Done Right](https://gabri.me/blog/git-worktrees-done-right) -- the bare repo
+  + worktree pattern that this template scaffolds.
+- [git-wt: Worktrees Simplified](https://gabri.me/blog/git-wt) -- a standalone CLI tool that
+  wraps the same pattern. Several of our mise tasks (`wt-update`, `wt-destroy`, fetch-before-add)
+  are inspired by `git-wt`'s approach. If you prefer a single CLI over mise tasks, check out
+  [git-wt](https://github.com/ahmedelgabri/git-wt).

--- a/template/.mise/tasks/wt-add
+++ b/template/.mise/tasks/wt-add
@@ -6,6 +6,11 @@ set -euo pipefail
 BRANCH="${1:?Usage: mise run wt-add <branch-name> [base-branch]}"
 BASE="${2:-main}"
 
+# Fetch latest from all remotes (skip if no remotes configured)
+if git remote | grep -q .; then
+  git fetch --all --quiet
+fi
+
 if git show-ref --verify --quiet "refs/heads/$BRANCH"; then
   # Local branch exists, check it out
   git worktree add "$BRANCH" "$BRANCH"

--- a/template/.mise/tasks/wt-destroy
+++ b/template/.mise/tasks/wt-destroy
@@ -1,0 +1,22 @@
+#!/bin/bash
+#MISE description="Remove a worktree and delete its local and remote branches"
+
+set -euo pipefail
+
+BRANCH="${1:?Usage: mise run wt-destroy <branch-name>}"
+
+if [ "$BRANCH" = "main" ]; then
+  echo "Error: refusing to destroy the main worktree." >&2
+  exit 1
+fi
+
+git worktree remove "$BRANCH"
+
+git branch -D "$BRANCH"
+
+if git remote | grep -q . && git ls-remote --exit-code --heads origin "$BRANCH" >/dev/null 2>&1; then
+  git push origin --delete "$BRANCH"
+  echo "Removed worktree, local branch, and remote branch '$BRANCH'"
+else
+  echo "Removed worktree and local branch '$BRANCH' (no remote branch found)"
+fi

--- a/template/.mise/tasks/wt-update
+++ b/template/.mise/tasks/wt-update
@@ -1,0 +1,20 @@
+#!/bin/bash
+#MISE description="Fetch all remotes and fast-forward the main branch"
+
+set -euo pipefail
+
+if ! git remote | grep -q .; then
+  echo "No remotes configured. Nothing to update." >&2
+  exit 1
+fi
+
+git fetch --all --quiet
+
+# Fast-forward main inside its worktree
+if git -C main merge --ff-only origin/main 2>/dev/null; then
+  echo "Updated main to $(git -C main rev-parse --short HEAD)"
+else
+  echo "Could not fast-forward main (diverged or worktree missing)." >&2
+  echo "  Resolve manually: cd main && git pull"
+  exit 1
+fi

--- a/template/AGENTS.md
+++ b/template/AGENTS.md
@@ -12,12 +12,14 @@ This project uses a **bare repo + worktree** structure. Read this before making 
 ├── <feature>/       # Worktree for a feature branch
 ├── .mise/
 │   └── tasks/       # Project tasks (run via mise)
-│       ├── wt-add      # Create a new worktree
-│       ├── wt-rm       # Remove a worktree
-│       ├── wt-ls       # List worktrees
+│       ├── wt-add       # Create a new worktree
+│       ├── wt-rm        # Remove a worktree
+│       ├── wt-destroy   # Remove worktree + local + remote branch
+│       ├── wt-ls        # List worktrees
+│       ├── wt-update    # Fetch remotes and fast-forward main
 │       ├── repo-public  # Create a public GitHub repo
 │       ├── repo-private # Create a private GitHub repo
-│       └── remote-add  # Add a remote to an existing repo
+│       └── remote-add   # Add a remote to an existing repo
 ├── .mise.toml       # Mise configuration
 ├── _/               # Scratchpad for notes and one-off scripts
 ├── .claude/         # Agent configuration (outside version control)
@@ -53,10 +55,19 @@ List active worktrees:
 mise run wt-ls
 ```
 
+Fetch latest from all remotes and fast-forward main:
+
+```bash
+mise run wt-update
+```
+
 Remove a worktree when done:
 
 ```bash
 mise run wt-rm my-feature
+
+# Or remove worktree + local + remote branch in one shot
+mise run wt-destroy my-feature
 ```
 
 ## Setting up a remote


### PR DESCRIPTION
## Summary

- **wt-add** now fetches all remotes before branching, so new worktrees always start from fresh remote state. Skips gracefully when no remotes are configured.
- **wt-update** (new task): fetches all remotes and fast-forwards the main worktree via `--ff-only`.
- **wt-destroy** (new task): removes worktree, deletes local branch, and deletes the remote branch in one shot. Refuses to touch main.
- Updated README and AGENTS.md with the new tasks, linked the followup post [git-wt: Worktrees Simplified](https://gabri.me/blog/git-wt), and expanded credits for Ahmed el Gabri.

Inspired by [git-wt](https://github.com/ahmedelgabri/git-wt).

## Test plan

- [ ] Scaffold a new project with a remote URL, verify `wt-add` fetches before creating the worktree
- [ ] Scaffold a new project without a remote URL, verify `wt-add` skips fetch without errors
- [ ] Run `wt-update` with a remote configured, verify main fast-forwards
- [ ] Run `wt-update` without remotes, verify clean error message
- [ ] Run `wt-destroy` on a branch with a remote counterpart, verify all three (worktree, local, remote) are removed
- [ ] Run `wt-destroy` on a local-only branch, verify worktree and local branch removed with appropriate message
- [ ] Run `wt-destroy main`, verify it refuses

🤖 Generated with [Claude Code](https://claude.com/claude-code)