### PR TITLE
feat: add template-update task for copier updates in bare repo projects

### DIFF
--- a/scripts/convert-to-worktree
+++ b/scripts/convert-to-worktree
@@ -192,7 +192,7 @@ convert_manually() {
   done
 
   # Install mise infrastructure
-  TASK_FILES=(wt-add wt-rm wt-ls repo-public repo-private remote-add)
+  TASK_FILES=(wt-add wt-rm wt-destroy wt-ls wt-update repo-public repo-private remote-add template-update)
   mkdir -p .mise/tasks
   for task in "${TASK_FILES[@]}"; do
     fetch_template_file ".mise/tasks/$task" ".mise/tasks/$task"
@@ -233,7 +233,7 @@ echo "Conversion complete!"
 echo "  Bare repo: .bare/"
 echo "  Worktree:  main/ ($MAIN_BRANCH)"
 if command -v uvx &>/dev/null; then
-  echo "  Update:    uvx copier update --trust"
+  echo "  Update:    mise run template-update"
 fi
 echo ""
 echo "Tasks (via mise):"

--- a/template/.mise/tasks/template-update
+++ b/template/.mise/tasks/template-update
@@ -1,0 +1,69 @@
+#!/bin/bash
+#MISE description="Update template files via copier (works around bare repo limitation)"
+
+# ABOUTME: Runs copier update in a temporary git repo, then syncs results back.
+# ABOUTME: Needed because copier rejects bare repo + worktree project roots.
+
+set -euo pipefail
+
+if ! command -v uvx &>/dev/null; then
+  echo "Error: uvx is required but not found. Install uv first." >&2
+  exit 1
+fi
+
+if [ ! -f .copier-answers.yml ]; then
+  echo "Error: .copier-answers.yml not found. Is this a copier-managed project?" >&2
+  exit 1
+fi
+
+# Collect directories to exclude from copy (worktrees, bare repo, scratch areas)
+EXCLUDE_ARGS=(--exclude .bare/ --exclude .git --exclude _/ --exclude .claude/)
+
+while IFS= read -r wt_path; do
+  [ -z "$wt_path" ] && continue
+  # Convert absolute worktree path to a name relative to project root
+  wt_name="${wt_path##*/}"
+  EXCLUDE_ARGS+=(--exclude "$wt_name/")
+done < <(git worktree list --porcelain | awk '/^worktree /{print $2}')
+
+# Resolve symlinks (macOS /var -> /private/var) so copier path comparisons work
+TMPDIR=$(realpath "$(mktemp -d)")
+trap 'rm -rf "$TMPDIR"' EXIT
+
+# Snapshot template-managed files before update
+rsync -a "${EXCLUDE_ARGS[@]}" ./ "$TMPDIR/"
+
+# Record files present before copier runs
+BEFORE=$(mktemp)
+(cd "$TMPDIR" && find . -not -path './.git/*' -not -name '.git' -type f | sort) > "$BEFORE"
+
+# Give copier a git repo to work with
+git -C "$TMPDIR" init --quiet
+git -C "$TMPDIR" add -A
+git -C "$TMPDIR" commit --quiet -m "pre-update snapshot"
+
+# Run copier update, passing through any extra args
+if ! uvx copier update --trust "$@" "$TMPDIR"; then
+  echo "Error: copier update failed." >&2
+  exit 1
+fi
+
+# Record files present after copier runs
+AFTER=$(mktemp)
+(cd "$TMPDIR" && find . -not -path './.git/*' -not -name '.git' -type f | sort) > "$AFTER"
+
+# Sync updated files back (exclude the temp git repo)
+rsync -a --exclude .git "$TMPDIR/" ./
+
+# Remove files that copier deleted (present before but not after)
+while IFS= read -r deleted; do
+  target="./$deleted"
+  if [ -f "$target" ]; then
+    rm "$target"
+    echo "Removed: $deleted"
+  fi
+done < <(comm -23 "$BEFORE" "$AFTER")
+
+rm -f "$BEFORE" "$AFTER"
+
+echo "Template update complete."

--- a/template/AGENTS.md
+++ b/template/AGENTS.md
@@ -19,7 +19,8 @@ This project uses a **bare repo + worktree** structure. Read this before making 
 │       ├── wt-update    # Fetch remotes and fast-forward main
 │       ├── repo-public  # Create a public GitHub repo
 │       ├── repo-private # Create a private GitHub repo
-│       └── remote-add   # Add a remote to an existing repo
+│       ├── remote-add       # Add a remote to an existing repo
+│       └── template-update  # Update template files via copier
 ├── .mise.toml       # Mise configuration
 ├── _/               # Scratchpad for notes and one-off scripts
 ├── .claude/         # Agent configuration (outside version control)
@@ -82,6 +83,24 @@ mise run repo-private owner/repo-name
 # Or add an existing remote and fetch branches
 mise run remote-add owner/repo
 ```
+
+## Updating template files
+
+This project was scaffolded from a copier template. To pull in template updates:
+
+```bash
+mise run template-update
+```
+
+Extra arguments are passed through to `copier update`:
+
+```bash
+mise run template-update -- --vcs-ref v0.2.0   # pin to a specific template version
+mise run template-update -- --defaults          # accept all defaults without prompting
+```
+
+The task copies template-managed files to a temporary git repo (since copier doesn't
+work in bare repo roots), runs the update there, and syncs results back.
 
 ## When running commands
 


### PR DESCRIPTION
## Summary

- Adds `template-update` mise task that wraps `copier update` with a temporary git repo, working around copier's rejection of bare repo project roots
- Updates `convert-to-worktree` summary to point users at `mise run template-update` instead of `uvx copier update --trust`
- Fixes `convert-to-worktree` manual fallback to install all task files (`wt-destroy`, `wt-update`, `template-update` were missing from the array)

## Test plan

- [x] Copied task to vibetuner, ran `mise run template-update -- --defaults` successfully
- [x] Verified `.copier-answers.yml` preserved correctly
- [x] Verified worktree structure and CLAUDE.md symlink intact after update
- [ ] Scaffold a fresh project, bump template, run `template-update`, confirm files update

🤖 Generated with [Claude Code](https://claude.com/claude-code)