### PR TITLE
fix: preserve gitignored files during convert-to-worktree

### DIFF
--- a/scripts/convert-to-worktree
+++ b/scripts/convert-to-worktree
@@ -93,6 +93,23 @@ fi
 echo "Converting $TARGET to worktree structure..."
 echo "  Main branch: $MAIN_BRANCH"
 
+# --- Preserve gitignored files ---
+# Gitignored files (e.g. .env) aren't tracked by git and would be destroyed
+# during conversion. Save them to a temp dir and restore to the project root.
+
+IGNORED_FILES=$(git ls-files --others --ignored --exclude-standard)
+IGNORED_BACKUP=""
+
+if [ -n "$IGNORED_FILES" ]; then
+  echo "  Git-ignored files found (will preserve in project root):"
+  echo "$IGNORED_FILES" | sed 's/^/    /'
+  IGNORED_BACKUP=$(mktemp -d)
+  while IFS= read -r f; do
+    mkdir -p "$IGNORED_BACKUP/$(dirname "$f")"
+    cp -a "$f" "$IGNORED_BACKUP/$f"
+  done <<< "$IGNORED_FILES"
+fi
+
 # ============================================================
 # Strategy 1: Use copier (preferred, gives .copier-answers.yml)
 # ============================================================
@@ -108,6 +125,7 @@ convert_with_copier() {
       mv "$BACKUP" "$TARGET"
       echo "Error: conversion failed. Original repository restored." >&2
     fi
+    rm -rf "${IGNORED_BACKUP:-}" 2>/dev/null || true
   }
   trap cleanup_backup EXIT
 
@@ -224,6 +242,17 @@ if command -v uvx &>/dev/null; then
 else
   echo "  (uvx not found, using manual conversion without .copier-answers.yml)"
   convert_manually
+fi
+
+# --- Restore gitignored files ---
+
+if [ -n "$IGNORED_BACKUP" ]; then
+  cd "$TARGET"
+  while IFS= read -r f; do
+    mkdir -p "$(dirname "$f")"
+    cp -a "$IGNORED_BACKUP/$f" "$f"
+  done <<< "$IGNORED_FILES"
+  rm -rf "$IGNORED_BACKUP"
 fi
 
 # --- Summary ---

--- a/tests/test_convert_preserves_gitignored.sh
+++ b/tests/test_convert_preserves_gitignored.sh
@@ -1,0 +1,78 @@
+#!/bin/bash
+# ABOUTME: Tests that convert-to-worktree preserves gitignored files in the project root.
+# ABOUTME: Validates both root-level and nested gitignored files survive conversion.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CONVERT="$SCRIPT_DIR/../scripts/convert-to-worktree"
+
+WORK=$(mktemp -d)
+trap 'rm -rf "$WORK"' EXIT
+
+fail() { echo "FAIL: $1" >&2; exit 1; }
+
+# --- Setup: create a git repo with tracked and gitignored files ---
+
+REPO="$WORK/test-repo"
+mkdir "$REPO"
+cd "$REPO"
+
+git init -b main --quiet
+git config user.email "test@test.com"
+git config user.name "Test"
+
+cat > .gitignore <<'EOF'
+*.env
+secret/
+EOF
+
+echo "tracked content" > file.txt
+echo "SECRET=password" > .env
+echo "LOCAL=value" > local.env
+mkdir -p secret
+echo "key=abc" > secret/api.key
+
+git add .gitignore file.txt
+git commit -m "initial" --quiet
+
+# --- Run conversion (manual path only, skip copier) ---
+
+# Strip uvx from PATH so the script falls through to manual conversion.
+# Keep all other tools available.
+ORIG_PATH="$PATH"
+TEMP_BIN="$WORK/bin"
+mkdir -p "$TEMP_BIN"
+# Symlink everything except uvx
+for bin_dir in ${PATH//:/ }; do
+  [ -d "$bin_dir" ] || continue
+  for f in "$bin_dir"/*; do
+    name="$(basename "$f")"
+    [ "$name" = "uvx" ] && continue
+    [ -e "$TEMP_BIN/$name" ] && continue
+    ln -sf "$f" "$TEMP_BIN/$name" 2>/dev/null || true
+  done
+done
+
+PATH="$TEMP_BIN" bash "$CONVERT" "$REPO"
+
+# --- Assertions ---
+
+# Gitignored files preserved in project root
+[ -f "$REPO/.env" ] || fail ".env not found in project root"
+[ "$(cat "$REPO/.env")" = "SECRET=password" ] || fail ".env content not preserved"
+
+[ -f "$REPO/local.env" ] || fail "local.env not found in project root"
+[ "$(cat "$REPO/local.env")" = "LOCAL=value" ] || fail "local.env content not preserved"
+
+[ -f "$REPO/secret/api.key" ] || fail "secret/api.key not found in project root"
+[ "$(cat "$REPO/secret/api.key")" = "key=abc" ] || fail "secret/api.key content not preserved"
+
+# Worktree created properly
+[ -d "$REPO/main" ] || fail "main worktree not created"
+[ -f "$REPO/main/file.txt" ] || fail "tracked file not in worktree"
+
+# Tracked files NOT duplicated in root
+[ ! -f "$REPO/file.txt" ] || fail "tracked file should not be in root"
+
+echo "PASS: gitignored files preserved in project root"


### PR DESCRIPTION
## Summary

- Gitignored files (e.g. `.env`, `secret/`) were silently destroyed during `convert-to-worktree` because neither the copier nor manual path carries untracked files
- Now detects gitignored files before conversion, warns about them, and restores them to the project root after conversion
- Covers both copier and manual conversion paths, including cleanup on copier failure

## Test plan

- [ ] Run `tests/test_convert_preserves_gitignored.sh` (validates root-level and nested gitignored files survive manual conversion)
- [ ] Manually test with copier path: create a repo with `.env`, run `convert-to-worktree`, verify `.env` is at project root
- [ ] Verify conversion without gitignored files still works (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)