### PR TITLE
feat: list recipes when just is invoked without arguments

### DIFF
--- a/template/justfile
+++ b/template/justfile
@@ -1,6 +1,10 @@
 # ABOUTME: Recipes for managing git worktrees and GitHub repos.
 # ABOUTME: Invoked via: uv run --from just-bin just <recipe>
 
+# List available recipes
+default:
+  @{{ just_executable() }} --list
+
 # Create a new git worktree for a branch
 wt-add branch base='main':
   #!/bin/bash


### PR DESCRIPTION
## Summary
- Adds a `default` recipe to the template justfile so running `just` with no arguments lists all available recipes
- Uses `just_executable()` to ensure it works when invoked via `uv run --from just-bin just`

## Test plan
- [ ] Run `just` with no arguments in a scaffolded project and verify it shows the recipe list

🤖 Generated with [Claude Code](https://claude.com/claude-code)