### PR TITLE
feat: accept folder paths in wt-rm and wt-destroy recipes

### DIFF
--- a/template/justfile
+++ b/template/justfile
@@ -33,12 +33,12 @@ wt-add branch base='main':
   fi
   echo "  cd $BRANCH/"
 
-# Remove a git worktree and its local branch
-wt-rm branch:
+# Remove a git worktree and its local branch (accepts branch name or folder path)
+wt-rm target:
   #!/bin/bash
   set -euo pipefail
 
-  BRANCH="{{ branch }}"
+  BRANCH="$(basename "{{ target }}")"
 
   if [ "$BRANCH" = "main" ]; then
     echo "Error: refusing to remove the main worktree." >&2
@@ -54,12 +54,12 @@ wt-rm branch:
     echo "Removed worktree and branch '$BRANCH'"
   fi
 
-# Remove a worktree and delete its local and remote branches
-wt-destroy branch:
+# Remove a worktree and delete its local and remote branches (accepts branch name or folder path)
+wt-destroy target:
   #!/bin/bash
   set -euo pipefail
 
-  BRANCH="{{ branch }}"
+  BRANCH="$(basename "{{ target }}")"
 
   if [ "$BRANCH" = "main" ]; then
     echo "Error: refusing to destroy the main worktree." >&2


### PR DESCRIPTION
## Summary
- `wt-rm` and `wt-destroy` now accept a folder path (e.g., `./my-feature/`) in addition to a branch name, using `basename` to resolve the branch
- Enables tab-completion of directories when removing worktrees
- Main worktree guard still works regardless of path format

## Test plan
- [ ] Run `just wt-add test-branch` then `just wt-rm ./test-branch/` and verify it removes correctly
- [ ] Run `just wt-rm main/` and verify it's rejected
- [ ] Run `just wt-destroy main` and verify it's rejected

🤖 Generated with [Claude Code](https://claude.com/claude-code)