### PR TITLE
feat: fast-forward base branch in wt-add and add recipe aliases

### DIFF
--- a/copier.yml
+++ b/copier.yml
@@ -21,3 +21,4 @@ git_remote_url:
   type: str
   help: Git remote URL to clone (leave empty to start a fresh repo)
   default: ""
+  when: "{{ _copier_operation == 'copy' }}"

--- a/template/justfile
+++ b/template/justfile
@@ -16,6 +16,17 @@ wt-add branch base='main':
   # Fetch latest from all remotes (skip if no remotes configured)
   if git remote | grep -q .; then
     git fetch --all --quiet
+
+    # Fast-forward the base branch so new branches start from the latest state
+    if git show-ref --verify --quiet "refs/remotes/origin/$BASE"; then
+      if [ -d "$BASE" ]; then
+        if git -C "$BASE" merge --ff-only "origin/$BASE" 2>/dev/null; then
+          echo "Updated $BASE to $(git -C "$BASE" rev-parse --short HEAD)"
+        else
+          echo "Warning: could not fast-forward $BASE (may have diverged from origin)." >&2
+        fi
+      fi
+    fi
   fi
 
   if git show-ref --verify --quiet "refs/heads/$BRANCH"; then
@@ -80,6 +91,16 @@ wt-destroy target:
 # List all active git worktrees
 wt-ls:
   git worktree list
+
+# Alias for wt-ls
+[private]
+wt-list:
+  @{{ just_executable() }} wt-ls
+
+# Alias for wt-rm
+[private]
+wt-remove target:
+  @{{ just_executable() }} wt-rm {{ target }}
 
 # Fetch all remotes and fast-forward the main branch
 wt-update:


### PR DESCRIPTION
## Summary

- **wt-add now fast-forwards the base branch** after fetching remotes, so new feature branches always start from the latest remote state. If the fast-forward fails (diverged or no worktree), it warns but doesn't block branch creation.
- **Adds `wt-list` and `wt-remove` aliases** for `wt-ls` and `wt-rm` (hidden from `just --list` to keep it clean).
- **Skips `git_remote_url` prompt during `template-update`** by adding `when: "{{ _copier_operation == 'copy' }}"` to the question. The URL is only relevant during initial scaffolding.

## Test plan

- [ ] Create a project with a remote, push a commit to main from elsewhere, then run `just wt-add feat` and verify it fast-forwards main before branching
- [ ] Run `just wt-add feat` with no remote configured and verify it still works (skips fast-forward)
- [ ] Run `just wt-list` and `just wt-remove <branch>` and verify they delegate correctly
- [ ] Run `just template-update` and verify it no longer asks for `git_remote_url`

🤖 Generated with [Claude Code](https://claude.com/claude-code)